### PR TITLE
8 add endpoint to copy files

### DIFF
--- a/server/src/main.py
+++ b/server/src/main.py
@@ -8,9 +8,9 @@ import humanize
 from clients.minio import client
 from fastapi import FastAPI, HTTPException, Request, Response, UploadFile, status
 from fastapi.middleware.cors import CORSMiddleware
+from minio.commonconfig import CopySource
 from minio.deleteobjects import DeleteObject
 from minio.error import S3Error
-from minio.commonconfig  import CopySource
 from models.file import File
 
 app = FastAPI()
@@ -211,35 +211,44 @@ async def delete_directory(workspace_id: str, path: str):
         f"DELETED {len(objects) - errors_count} of {len(objects)} object(s) from {path} in {workspace_id}."
     )
 
-@app.put("/workspaces/{workspace_id}/cp/{path:path}")
-async def copy_file(workspace_id: str, path: str, target_path: str):
+
+@app.put(
+    "/workspaces/{workspace_id}/cp/{path:path}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def copy_file(
+    workspace_id: str,
+    path: str,
+    target_path: str,
+    target_workspace_id: Optional[str] = None,
+):
+    """
+    Asynchronously copies a file from one workspace to another.
+
+    Args:
+      workspace_id (str): The ID of the workspace containing the source file.
+      path (str): The path of the source file within the workspace.
+      target_path (str): The path where the file should be copied to in the target workspace.
+      target_workspace_id (Optional[str], optional): The ID of the target workspace. If not provided, defaults to the source workspace ID.
+
+    Raises:
+      HTTPException: If the source file is not found in the specified workspace.
+
+    Logs:
+      Info: Logs the source and target paths along with their respective workspace IDs after a successful copy operation.
+    """
+    target_workspace_id = (
+        workspace_id if target_workspace_id is None else target_workspace_id
+    )
     try:
-      source = CopySource(workspace_id, path)
-      client.copy_object(workspace_id,path,source)
+        source = CopySource(workspace_id, path)
+        client.copy_object(target_workspace_id, target_path, source)
+
     except S3Error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"404_NOT_FOUND: {path} not found in {workspace_id}",
         )
-
-
-
-def copy_args (workspace_id:str,path:str,obj:Object):
-  source_obj = client.get_object(workspace_id, path)
-  
-  
-  
-  source_obj.release_conn()
-  
-  return copy_args
-
-# @app.put("/workspaces/{workspace_id}/cp/{path:path}")
-# async def copy_file(workspace_id: str, path: str, target_path: str):
-#     try:
-#       source = CopySource(workspace_id, path)
-#       client.copy_object(workspace_id,path,source)
-#     except S3Error:
-#         raise HTTPException(
-#             status_code=status.HTTP_404_NOT_FOUND,
-#             detail=f"404_NOT_FOUND: {path} not found in {workspace_id}",
-#         )
+    logger.info(
+        f"Copied {path} in {workspace_id} TO {target_path} in {target_workspace_id}"
+    )

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException, Request, Response, UploadFile, statu
 from fastapi.middleware.cors import CORSMiddleware
 from minio.deleteobjects import DeleteObject
 from minio.error import S3Error
+from minio.commonconfig  import CopySource
 from models.file import File
 
 app = FastAPI()
@@ -209,3 +210,36 @@ async def delete_directory(workspace_id: str, path: str):
     logger.info(
         f"DELETED {len(objects) - errors_count} of {len(objects)} object(s) from {path} in {workspace_id}."
     )
+
+@app.put("/workspaces/{workspace_id}/cp/{path:path}")
+async def copy_file(workspace_id: str, path: str, target_path: str):
+    try:
+      source = CopySource(workspace_id, path)
+      client.copy_object(workspace_id,path,source)
+    except S3Error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"404_NOT_FOUND: {path} not found in {workspace_id}",
+        )
+
+
+
+def copy_args (workspace_id:str,path:str,obj:Object):
+  source_obj = client.get_object(workspace_id, path)
+  
+  
+  
+  source_obj.release_conn()
+  
+  return copy_args
+
+# @app.put("/workspaces/{workspace_id}/cp/{path:path}")
+# async def copy_file(workspace_id: str, path: str, target_path: str):
+#     try:
+#       source = CopySource(workspace_id, path)
+#       client.copy_object(workspace_id,path,source)
+#     except S3Error:
+#         raise HTTPException(
+#             status_code=status.HTTP_404_NOT_FOUND,
+#             detail=f"404_NOT_FOUND: {path} not found in {workspace_id}",
+#         )


### PR DESCRIPTION
## Adds endpoint to copy files

- workspace_id (str): The ID of the workspace containing the source file.
- path (str): The path of the source file within the workspace.
- target_path (str): The path where the file should be copied to in the target workspace.
-  target_workspace_id (Optional[str], optional): The ID of the target workspace. If not provided, defaults to the source workspace ID