### PR TITLE
45 add unit tests for stat endpoint

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -851,6 +851,24 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1311,4 +1329,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "92fa61e820b66459a58f0af1a8f924b2d5c0db644a68395f6084a0edea542bd9"
+content-hash = "b4ff059cdb53a76c080b39e5f4886bae4ca96ad9929060475a34e5d09817c450"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "minio (>=7.2.15,<8.0.0)",
     "rich (>=13.9.4,<14.0.0)",
     "humanize (>=4.12.1,<5.0.0)",
-    "pytest (>=8.3.5,<9.0.0)"
+    "pytest (>=8.3.5,<9.0.0)",
+    "pytest-mock (>=3.14.0,<4.0.0)"
 ]
 
 [tool.poetry]

--- a/server/tests/test_main.py
+++ b/server/tests/test_main.py
@@ -2,13 +2,56 @@ import pytest
 from fastapi.testclient import TestClient
 from fastapi import status
 from src.main import app
+from src.repositories.files.fastapi import get_file_repository
+from src.repositories.files.base import FileRepository
+from minio.error import S3Error
 
 
 @pytest.fixture
 def test_client():
-    return TestClient(app)
+    yield TestClient(app)
+    app.dependency_overrides = {}
 
 
 def test_ready(test_client):
     response = test_client.get("/ready")
     assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_stat_successful(mocker, test_client):
+    mock_file_repository = mocker.MagicMock(
+        spec=FileRepository,
+    )
+    mock_file_repository.stat = mocker.AsyncMock(return_value=[])
+    app.dependency_overrides[get_file_repository] = lambda: mock_file_repository
+
+    response = test_client.get(
+        "/workspaces/test_workspace_id/stat/some/path",
+    )
+
+    mock_file_repository.stat.assert_called_once_with(
+        "test_workspace_id",
+        "some/path",
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_stat_failure(mocker, test_client):
+    mock_file_repository = mocker.MagicMock(
+        spec=FileRepository,
+    )
+    mock_file_repository.stat = mocker.AsyncMock(
+        side_effect=S3Error(None, None, None, None, None, None)
+    )
+    app.dependency_overrides[get_file_repository] = lambda: mock_file_repository
+    response = test_client.get(
+        "/workspaces/test_workspace_id/stat/some/path",
+    )
+    mock_file_repository.stat.assert_called_once_with(
+        "test_workspace_id",
+        "some/path",
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "detail": "404_NOT_FOUND: some/path not found in test_workspace_id"
+    }

--- a/server/tests/test_main.py
+++ b/server/tests/test_main.py
@@ -5,6 +5,9 @@ from src.main import app
 from src.repositories.files.fastapi import get_file_repository
 from src.repositories.files.base import FileRepository
 from minio.error import S3Error
+from src.models.file import File, Directory
+from datetime import datetime
+from fastapi.encoders import jsonable_encoder
 
 
 @pytest.fixture
@@ -22,18 +25,31 @@ def test_stat_successful(mocker, test_client):
     mock_file_repository = mocker.MagicMock(
         spec=FileRepository,
     )
-    mock_file_repository.stat = mocker.AsyncMock(return_value=[])
+    mock_response = [
+        File(
+            name="some/path/test_file.txt",
+            basename="test_file.txt",
+            path="some/path",
+            content_type="text/plain",
+            size=100,
+            last_modified=datetime.now(),
+        ),
+        Directory(
+            name="some/path/subdir/",
+            path="some/path",
+        ),
+    ]
+    mock_file_repository.stat = mocker.AsyncMock(return_value=mock_response)
     app.dependency_overrides[get_file_repository] = lambda: mock_file_repository
-
     response = test_client.get(
         "/workspaces/test_workspace_id/stat/some/path",
     )
-
     mock_file_repository.stat.assert_called_once_with(
         "test_workspace_id",
         "some/path",
     )
     assert response.status_code == status.HTTP_200_OK
+    assert response.json() == jsonable_encoder(mock_response)
 
 
 def test_stat_failure(mocker, test_client):


### PR DESCRIPTION
This PR adds the `pytest-mock` dependency and adds a unit test for the success & failure case of the stat endpoint.